### PR TITLE
Render a CloakVisual when responsive props not present for responsive-craft-visual

### DIFF
--- a/adapters/globals/responsive-craft-visual.coffee
+++ b/adapters/globals/responsive-craft-visual.coffee
@@ -2,6 +2,7 @@
 Render Responsive Visual where the responsive fields come from Craft
 ###
 import CloakResponsiveVisual from '../../components/responsive'
+import CloakVisual from '../../components/visual'
 import { aspectRatioFromImage } from './craft-visual'
 export default
 	functional: true
@@ -15,19 +16,47 @@ export default
 		video: Object | Array
 	}
 
-	# Make the responsive component
+	# Make the visual component
 	render: (create, { props, data }) ->
-		create CloakResponsiveVisual, {
+
+		# Get props that responsive visual expects
+		props =	{
+			...props
+			...expandSuperTableAssets props
+		}
+
+		# Render a responsive visual if at least one of the responsive props has
+		# values for both landscape and portarit
+		if (props.landscapeImage and props.portraitImage) ||
+			(props.landscapeVideo and props.portraitVideo) ||
+			(props.landscapeAspect and props.portraitAspect)
+		then create CloakResponsiveVisual, {
 			...data
 			props: {
 				...props
 
-				# Consume Super Table props
-				...expandSuperTableAssets props
-
 				# Remove Super Table field values now that they've been mapped
 				image: undefined
 				video: undefined
+			}
+		}
+
+		# Otherwsie, render a standard cloak-visual
+		else create CloakVisual, {
+			...data
+			props: {
+				...props
+				image: props.landscapeImage || props.portraitImage || props.image
+				video: props.landscapeVideo || props.portraitVideo || props.video
+				aspect: props.landscapeAspect || props.portraitAspect || props.aspect
+
+				# Remove responsive field values
+				landscapeImage: undefined
+				portraitImage: undefined
+				landscapeVideo: undefined
+				portraitVideo: undefined
+				landscapeAspect: undefined
+				portraitAspect: undefined
 			}
 		}
 

--- a/demo/content/demo.md
+++ b/demo/content/demo.md
@@ -96,3 +96,94 @@ The block component simply renders a 100% width Visual within the max-width gutt
   alt='Cyberpunk vibes demo image'>
 </cloak-visual-block>
 ```
+
+## Craft Visuals
+
+Use the Craft adapter components to render Visual instances from Craft objects.  This example shows using `<responsive-craft-visual>` using a SuperTable image and video fields, where only one landscape image was provided. As a result, a non-responsive `<cloak-visual>` component is rendered.
+
+<responsive-craft-visual
+  :image='[{
+      "id":"7884",
+      "landscape":[{
+        "id":"1193",
+        "width":1324,
+        "height":745,
+        "title":"Retreat",
+        "mimeType":"image/jpeg",
+        "focalPoint":[0.5,0.5],
+        "path":"retreat.jpg",
+        "url":"/assets/landscape.jpg"
+      }],
+      "portrait":[]
+    }]'>
+</responsive-craft-visual>
+
+```vue
+<responsive-craft-visual
+  :image='[{
+      "id":"7884",
+      "landscape":[{
+        "id":"1193",
+        "width":3840,
+        "height":2160,
+        "title":"Retreat",
+        "mimeType":"image/jpeg",
+        "focalPoint":[0.5,0.5],
+        "url":"/assets/landscape.jpg"
+      }],
+      "portrait":[]
+    }]'>
+</responsive-craft-visual>
+```
+
+However, if multiple asssets are provided, a `<cloak-responsive>` instance is rendered:
+
+<responsive-craft-visual
+  :image='[{
+      "id":"7884",
+      "landscape":[{
+        "id":"1193",
+        "width":3840,
+        "height":2160,
+        "title":"Retreat",
+        "mimeType":"image/jpeg",
+        "focalPoint":[0.5,0.5],
+        "url":"/assets/landscape.jpg"
+      }],
+      "portrait":[{
+        "id":"1193",
+        "width":2160,
+        "height":2160,
+        "title":"Retreat",
+        "mimeType":"image/jpeg",
+        "focalPoint":[0.5,0.5],
+        "url":"/assets/portrait.png"
+      }]
+    }]'>
+</responsive-craft-visual>
+
+```vue
+<responsive-craft-visual
+  :image='[{
+      "id":"7884",
+      "landscape":[{
+        "id":"1193",
+        "width":3840,
+        "height":2160,
+        "title":"Retreat",
+        "mimeType":"image/jpeg",
+        "focalPoint":[0.5,0.5],
+        "url":"/assets/landscape.jpg"
+      }],
+      "portrait":[{
+        "id":"1193",
+        "width":2160,
+        "height":2160,
+        "title":"Retreat",
+        "mimeType":"image/jpeg",
+        "focalPoint":[0.5,0.5],
+        "url":"/assets/portrait.png"
+      }]
+    }]'>
+</responsive-craft-visual>
+```


### PR DESCRIPTION
Without this change, if only one responsive asset is specified, it's aspect ratio is passed use at it's orientation but at the other orientation, it defaults to natural size.  The effect is typically the same but it's inconsistent and different from previous behavior and I worry it could lead to issues.