### PR TITLE
return empty alt with no description is provided

### DIFF
--- a/adapters/globals/sanity-visual.js
+++ b/adapters/globals/sanity-visual.js
@@ -29,7 +29,7 @@ export default {
         video: getVideoUrl(props.video),
         aspect: props.aspect ||
           props.image?.asset?.metadata?.dimensions?.aspectRatio,
-        alt: props.alt || props.image?.alt,
+        alt: props.alt || props.image?.alt || "",
         objectPosition: props.objectPosition || makeObjectPosition(props.image),
 
         // Apply cropping


### PR DESCRIPTION
PR to implement fallback to an empty alt text when no description is provided. Decorative images should have an empty `alt=''` attribute, this tells screen readers that they should skip announcing the image, looks like having `alt=''` is different than omitting it. Got this callout in a couple of Foxhole QA tickets for Ollion. 