### PR TITLE
Don't support srcset for GIF

### DIFF
--- a/plugins/helpers.js
+++ b/plugins/helpers.js
@@ -78,6 +78,8 @@ export function srcset(url, sizes, modifiers, options, {
 	$cloakImg, maxWidth
 } = {}) {
 	if (!url || !sizes) return
+	// Don't support srcset for GIF
+	if (url.toLowerCase().endsWith('.gif')) return
 
 	// Don't output src options that are greater then a 2X version of the max
 	// width


### PR DESCRIPTION
https://app.asana.com/0/1205224826010742/1207164635521719
https://bkwld.slack.com/archives/C06P075CGQ7/p1729516329939719

Both these issues have request the same solution for supporting GIF in `cloak-app/visual` and it seems like GIF doesn't like to have size restraint on ImgIX. Thus we are removing `srcset` for it